### PR TITLE
Remove unused min define

### DIFF
--- a/src/JPEGDecoder.h
+++ b/src/JPEGDecoder.h
@@ -73,10 +73,6 @@ enum {
   #define jpg_min(a,b)     (((a) < (b)) ? (a) : (b))
 #endif
 
-#ifndef min
-  #define min(a,b) (((a) < (b)) ? (a) : (b))
-#endif
-
 //------------------------------------------------------------------------------
 typedef unsigned char uint8;
 typedef unsigned int uint;


### PR DESCRIPTION
Not sure where this is used in the first place, seems like the `jpg_min` define is the one that's used now.
Remove unused min define as it causes compilation errors when
compiling with ESP-IDF and the C++14 STL.

Not sure if this clashes with some C function or something, since the STL `min` should be in the `std` namespace.

```
/Users/sierenmusic/Documents/Development/HC2/HomeControl/main/libraries/JPEGDecoder/src/JPEGDecoder.h:77:20: error: expected unqualified-id before '(' token
   #define min(a,b) (((a) < (b)) ? (a) : (b))
                    ^
[ 10%] Building C object esp-idf/driver/CMakeFiles/idf_component_driver.dir/rmt.c.obj
/Users/sierenmusic/Documents/Development/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/bits/locale_conv.h: In member function 'bool std::wbuffer_convert<_Codecvt, _Elem, _Tr>::_M_conv_get()':
/Users/sierenmusic/Documents/Development/HC2/HomeControl/main/libraries/JPEGDecoder/src/JPEGDecoder.h:77:20: error: expected unqualified-id before '(' token
   #define min(a,b) (((a) < (b)) ? (a) : (b))
                    ^
/Users/sierenmusic/Documents/Development/HC2/HomeControl/main/libraries/JPEGDecoder/src/JPEGDecoder.h:77:20: error: expected unqualified-id before '(' token
   #define min(a,b) (((a) < (b)) ? (a) : (b))
```