### PR TITLE
Fix signed/unsigned comparision warning

### DIFF
--- a/src/JPEGDecoder.cpp
+++ b/src/JPEGDecoder.cpp
@@ -70,7 +70,7 @@ uint8_t JPEGDecoder::pjpeg_need_bytes_callback(uint8_t* pBuf, uint8_t buf_size, 
 	n = jpg_min(g_nInFileSize - g_nInFileOfs, buf_size);
 
 	if (jpg_source == JPEG_ARRAY) { // We are handling an array
-		for (int i = 0; i < n; i++) {
+		for (uint i = 0; i < n; i++) {
 			pBuf[i] = pgm_read_byte(jpg_data++);
 			//Serial.println(pBuf[i],HEX);
 		}


### PR DESCRIPTION
Fixes `comparison between signed and unsigned integer expressions [-Wsign-compare]`

'cause it's always good to shut that damn compiler up!