### PR TITLE
disabled unused macro declaration that was causing conflict

### DIFF
--- a/src/JPEGDecoder.h
+++ b/src/JPEGDecoder.h
@@ -45,12 +45,12 @@ https://github.com/Bodmer/JPEGDecoder
     #include <pgmspace.h>
     #include <FS.h>
     #include <LittleFS.h>
-    #define SPIFFS LittleFS
+//    #define SPIFFS LittleFS
   #elif defined (ARDUINO_ARCH_RP2040)
     #define LOAD_FLASH_FS
     #include <FS.h>
     #include <LittleFS.h>
-    #define SPIFFS LittleFS
+//    #define SPIFFS LittleFS
     #define TJPGD_LOAD_FFS
   #endif
 


### PR DESCRIPTION
disabled SPIFFS redeclaration that was creating declaration conflict as a byproduct in sources that would include JPEGDecoder.h This was the cause of error:
JPEGDecoder.h:48:20: error: conflicting declaration 'fs::SPIFFSFS LittleFS'
whenever JPEGDecoder.h was included before inclusion of SPIFFS-related headers, such as TFT_eSPI.h.